### PR TITLE
feat: 네이버 사이트 인증을 위한 메타 태그 추가

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,6 +26,12 @@ export default function App({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="msapplication-TileColor" content="#FBFBFB" />
         <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
+
+        {/* Naver Site Verification*/}
+        <meta
+          name="naver-site-verification"
+          content="84f0f3ab096b92356efeaffe9b0a3f7bfb6e778e"
+        />
       </Head>
 
       <Script


### PR DESCRIPTION
## 📝 Description

- 네이버 사이트 인증을 위한 메타 태그를 pages/_app.tsx의 head 태그 안에 추가했습니다. 

![image](https://github.com/Sae-sak/SAK-Exhibition/assets/115343657/e2cccaaf-bf25-4aac-903a-af728bee48ec)
